### PR TITLE
Update readme to say you need >=IDEA 13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To normal work this plugin need:
 ## Source compilation
 
 To normal compilation you will need:
-* IDEA 13
+* IDEA 13.1
 * Kotlin plugin
 * JDK 6
 * IntelliJ IDEA Plugin SDK


### PR DESCRIPTION
If you are on IDEA 13.0 the plugin does not appear in the plugin download list as it is incompatible.
