### PR TITLE
Fixes #64 Kotlin Runtime is added to the classpath to fix a NoClassDefFoundError.

### DIFF
--- a/plugin/src/org/jetbrains/cabal/CabalManager.kt
+++ b/plugin/src/org/jetbrains/cabal/CabalManager.kt
@@ -13,6 +13,7 @@ import com.intellij.openapi.util.Pair
 import com.intellij.execution.ExecutionException
 import com.intellij.execution.configurations.SimpleJavaParameters
 import com.intellij.util.Function
+import com.intellij.util.PathUtil
 import org.jetbrains.haskell.icons.HaskellIcons
 import org.jetbrains.cabal.settings.*
 import org.jetbrains.cabal.export.*
@@ -43,7 +44,10 @@ public class CabalManager()
     }
 
     throws(javaClass<ExecutionException>())
-    override fun enhanceRemoteProcessing(parameters: SimpleJavaParameters) { }
+    override fun enhanceRemoteProcessing(parameters: SimpleJavaParameters) {
+        val kotlinJarPath = PathUtil.getJarPathForClass(kotlin.Unit.javaClass)
+        parameters.getClassPath().add(kotlinJarPath)
+    }
 
     override fun enhanceLocalProcessing(urls: List<URL>) {  }
 

--- a/plugin/src/org/jetbrains/cabal/export/CabalProjectResolver.kt
+++ b/plugin/src/org/jetbrains/cabal/export/CabalProjectResolver.kt
@@ -3,12 +3,10 @@ package org.jetbrains.cabal.export
 import com.intellij.openapi.externalSystem.model.DataNode
 import com.intellij.openapi.externalSystem.model.ExternalSystemException
 import com.intellij.openapi.externalSystem.model.project.ProjectData
+import com.intellij.openapi.externalSystem.model.settings.ExternalSystemExecutionSettings
 import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskId
 import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskNotificationListener
-import com.intellij.openapi.externalSystem.model.settings.ExternalSystemExecutionSettings
 import com.intellij.openapi.externalSystem.service.project.ExternalSystemProjectResolver
-//import java.io.File
-import java.util.*
 
 public class CabalProjectResolver(): ExternalSystemProjectResolver<ExternalSystemExecutionSettings> {
 

--- a/plugin/src/org/jetbrains/cabal/export/CabalTaskManager.kt
+++ b/plugin/src/org/jetbrains/cabal/export/CabalTaskManager.kt
@@ -1,13 +1,10 @@
 package org.jetbrains.cabal.export
 
-import com.intellij.openapi.externalSystem.task.ExternalSystemTaskManager
-
 import com.intellij.openapi.externalSystem.model.ExternalSystemException
 import com.intellij.openapi.externalSystem.model.settings.ExternalSystemExecutionSettings
 import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskId
 import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskNotificationListener
-
-import java.io.File
+import com.intellij.openapi.externalSystem.task.ExternalSystemTaskManager
 
 public class CabalTaskManager() : ExternalSystemTaskManager<ExternalSystemExecutionSettings> {
 


### PR DESCRIPTION
CabalProjectResolver and CabalTaskManager are executed in the separate
process which didn't have Kotlin runtime on the classpath.
ExternalSystemManager API is used in order to add it there.

I have not enabled the import in the plugin.xml, because it seem half-baked.