### PR TITLE
Fix #94

### DIFF
--- a/plugin/src/org/jetbrains/haskell/external/GhcModi.kt
+++ b/plugin/src/org/jetbrains/haskell/external/GhcModi.kt
@@ -117,7 +117,7 @@ public class GhcModi(val project: Project, val settings: HaskellSettings) : Proj
                         break
                     }
                     val result = String(char, 0, size)
-                    val split = result.splitBy(OSUtil.newLine, limit = -1)
+                    val split = result.splitBy(OSUtil.newLine, limit = 0)
                     if (lines.isEmpty()) {
                         lines.add(split[0])
                     } else {


### PR DESCRIPTION
On Linux x64 (at least) the problem still persists. The problem is that in order to have unlimited splits, in splitBy, limit must be 0, not -1. I have chaned this and checked it that it works.