### PR TITLE
Fix #59

### DIFF
--- a/plugin/src/org/jetbrains/haskell/actions/ShowTypeAction.kt
+++ b/plugin/src/org/jetbrains/haskell/actions/ShowTypeAction.kt
@@ -90,9 +90,7 @@ public class ShowTypeAction : AnAction() {
         val result = list.map { typeInfoFromString(it) }.filterNotNull()
         val typeInfo = result.firstOrNull {
             it.startLine == start.myLine &&
-            it.startCol == start.myColumn &&
-            it.endLine == end.myLine &&
-            it.endCol == end.myColumn
+            it.startCol == start.myColumn
         }
         if (typeInfo != null) {
             HintManager.getInstance()!!.showInformationHint(editor, typeInfo.aType)


### PR DESCRIPTION
I have the same problem using GHC 7.10 and ghc-mod master (at least as of commit 9cefeff17f).
More specifically, I experience it in two cases: one when I ask for the type of let bound identifiers, and secondly when I ask for the type of top level identifiers.

Examining the output of ghc-modi it appears that the type of the identifier at the cursor position is always reported first AND at least for let bound and top level identifiers the reported end line and column is the end of the whole definition, NOT the end of the identifier.
The code in searches for a result with both the start and end of the identier, while ghc-modi reports the start of the identifier, buth the end of the whole definition, and the search thus fails.
